### PR TITLE
Remove `window` reference in server-side code

### DIFF
--- a/src/Server.coffee
+++ b/src/Server.coffee
@@ -139,4 +139,4 @@ class Server
     console.log "[Server] Disconnecting:", client
 
 
-window.server = new Server
+server = new Server


### PR DESCRIPTION
Server-side node doesn't have a window global variable; this change was necessary to get the server to run.